### PR TITLE
link to AAI 1.2-draft-main published branch

### DIFF
--- a/researcher_ids/README.md
+++ b/researcher_ids/README.md
@@ -3,7 +3,7 @@
 ## Quick Links
 
 - [GA4GH Passport Specification](http://bit.ly/ga4gh-passport-v1)
-- [GA4GH Authentication and Authorization Infrastructure (AAI) OpenID Connect Profile](http://bit.ly/ga4gh-aai-profile)
+- [GA4GH Authentication and Authorization Infrastructure (AAI) OpenID Connect Profile](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile)
 - [Update Procedure](UPDATE_PROCEDURE.md) for Researcher IDs content 
 
 ## Introduction
@@ -22,7 +22,7 @@ The genomics community was therefore in need of:
 
 GA4GH Passport specification aims to support data access policies within current and evolving data access governance systems. This specification defines [Passports](http://bit.ly/ga4gh-passport-v1#passport) and [Passport Visas](http://bit.ly/ga4gh-passport-v1#passport-visa) as the standard way of communicating the data access authorizations that a user has based on either their role (e.g. researcher), affiliation, or access status. Passport Visas from trusted organizations can therefore express data access authorizations that require either a registration process (for the [Registered Access data access model](https://doi.org/10.1038/s41431-018-0219-y)) or custom data access approval (such as the Controlled Access applications used for many datasets).
 
-Data access authorization information is encoded as Passports and transmitted according to [GA4GH AAI Specification](http://bit.ly/ga4gh-aai-profile). Passports are consumed to provide access to the user in a technical environment. For example, to support Registered Access, Passports allow for the encoding and identification of users with Bona Fide Researcher Registered Access status. To simplify access to multiple data sets, multiple Passport Visas that a user has acquired to authorize dataset access may be used simultaneously.
+Data access authorization information is encoded as Passports and transmitted according to [GA4GH AAI Specification](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile). Passports are consumed to provide access to the user in a technical environment. For example, to support Registered Access, Passports allow for the encoding and identification of users with Bona Fide Researcher Registered Access status. To simplify access to multiple data sets, multiple Passport Visas that a user has acquired to authorize dataset access may be used simultaneously.
 
 Organizations and individuals issuing and using Passport Visas must adhere to corresponding data access and data protection policies and regulations, with respect to both the data to which Passport Visas may be used to gain access, and to the personal data of the individual to which Passport Visas apply.
 
@@ -321,7 +321,7 @@ An example Passport Visa payload:
 
 In the example above, the user has been granted access to dataset 33333 by the
 National Cancer Institute's DAC which is using dbGaP to present the claim as the
-[Broker](http://bit.ly/ga4gh-aai-profile#term-broker).
+[Broker](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-broker).
 
 It is important to note that the token issuer ("iss") may not be the same
 organization represented by the "source" field, as shown in the example above.
@@ -460,12 +460,12 @@ one Passport from trusted sources, that Registered Access may apply to the
 researcher in question. In this case, a Passport Clearinghouse that would
 accept these Passport Visas must trust the Brokers of ELIXIR and Heidelberg
 University as well as both [Claim Source
-organizations](http://bit.ly/ga4gh-aai-profile#term-claim-source) encoded in the
+organizations](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-claim-source) encoded in the
 "[source](http://bit.ly/ga4gh-passport-v1#source)" field (i.e. both Cambridge University
 and Heidelberg University). The "[by](http://bit.ly/ga4gh-passport-v1#by)" field must
 also be acceptable based on policies for the Passport Clearinghouse in addition to
 other validation of the tokens and fields as described in the [AAI
-specification](http://bit.ly/ga4gh-aai-profile) and the [Passport
+specification](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile) and the [Passport
 specification](http://bit.ly/ga4gh-passport-v1).
 
 ## Why so many expiry timestamps?

--- a/researcher_ids/README.md
+++ b/researcher_ids/README.md
@@ -3,7 +3,7 @@
 ## Quick Links
 
 - [GA4GH Passport Specification](http://bit.ly/ga4gh-passport-v1)
-- [GA4GH Authentication and Authorization Infrastructure (AAI) OpenID Connect Profile](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile)
+- [GA4GH Authentication and Authorization Infrastructure (AAI) OpenID Connect Profile](https://ga4gh.github.io/data-security/aai-openid-connect-profile)
 - [Update Procedure](UPDATE_PROCEDURE.md) for Researcher IDs content 
 
 ## Introduction
@@ -22,7 +22,7 @@ The genomics community was therefore in need of:
 
 GA4GH Passport specification aims to support data access policies within current and evolving data access governance systems. This specification defines [Passports](http://bit.ly/ga4gh-passport-v1#passport) and [Passport Visas](http://bit.ly/ga4gh-passport-v1#passport-visa) as the standard way of communicating the data access authorizations that a user has based on either their role (e.g. researcher), affiliation, or access status. Passport Visas from trusted organizations can therefore express data access authorizations that require either a registration process (for the [Registered Access data access model](https://doi.org/10.1038/s41431-018-0219-y)) or custom data access approval (such as the Controlled Access applications used for many datasets).
 
-Data access authorization information is encoded as Passports and transmitted according to [GA4GH AAI Specification](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile). Passports are consumed to provide access to the user in a technical environment. For example, to support Registered Access, Passports allow for the encoding and identification of users with Bona Fide Researcher Registered Access status. To simplify access to multiple data sets, multiple Passport Visas that a user has acquired to authorize dataset access may be used simultaneously.
+Data access authorization information is encoded as Passports and transmitted according to [GA4GH AAI Specification](https://ga4gh.github.io/data-security/aai-openid-connect-profile). Passports are consumed to provide access to the user in a technical environment. For example, to support Registered Access, Passports allow for the encoding and identification of users with Bona Fide Researcher Registered Access status. To simplify access to multiple data sets, multiple Passport Visas that a user has acquired to authorize dataset access may be used simultaneously.
 
 Organizations and individuals issuing and using Passport Visas must adhere to corresponding data access and data protection policies and regulations, with respect to both the data to which Passport Visas may be used to gain access, and to the personal data of the individual to which Passport Visas apply.
 
@@ -321,7 +321,7 @@ An example Passport Visa payload:
 
 In the example above, the user has been granted access to dataset 33333 by the
 National Cancer Institute's DAC which is using dbGaP to present the claim as the
-[Broker](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-broker).
+[Broker](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-broker).
 
 It is important to note that the token issuer ("iss") may not be the same
 organization represented by the "source" field, as shown in the example above.
@@ -460,12 +460,12 @@ one Passport from trusted sources, that Registered Access may apply to the
 researcher in question. In this case, a Passport Clearinghouse that would
 accept these Passport Visas must trust the Brokers of ELIXIR and Heidelberg
 University as well as both [Claim Source
-organizations](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-claim-source) encoded in the
+organizations](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-claim-source) encoded in the
 "[source](http://bit.ly/ga4gh-passport-v1#source)" field (i.e. both Cambridge University
 and Heidelberg University). The "[by](http://bit.ly/ga4gh-passport-v1#by)" field must
 also be acceptable based on policies for the Passport Clearinghouse in addition to
 other validation of the tokens and fields as described in the [AAI
-specification](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile) and the [Passport
+specification](https://ga4gh.github.io/data-security/aai-openid-connect-profile) and the [Passport
 specification](http://bit.ly/ga4gh-passport-v1).
 
 ## Why so many expiry timestamps?

--- a/researcher_ids/ga4gh_passport_v1.md
+++ b/researcher_ids/ga4gh_passport_v1.md
@@ -35,19 +35,19 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 This specification inherits terminology from the 
-[GA4GH AAI OIDC Profile](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#terminology)
+[GA4GH AAI OIDC Profile](https://ga4gh.github.io/data-security/aai-openid-connect-profile#terminology)
 specification, namely these terms:
 
-* <a name="term-passport"></a>**[Passport](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-passport)**
-* <a name="term-passport-scoped-access-token"></a>**[Passport-Scoped Access Token](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-passport-scoped-access-token)**
-* <a name="term-passport-clearinghouse"></a>**[Passport Clearinghouse](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-passport-clearinghouse)**
-* <a name="term-visa-assertion"></a>**[Visa Assertion](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-visa-assertion)**
-* <a name="term-visa-assertion-source"></a>**[Visa Assertion Source](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-visa-assertion-source)**
-* <a name="term-visa-issuer"></a>**[Visa Issuer](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-visa-issuer)**
-* <a name="term-visa"></a>**[Visa](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-visa)**
-* <a name="term-jwt"></a>**[JWT](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-jwt)**
-* <a name="term-ga4gh-claim"></a>**[GA4GH Claim](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-ga4gh-claim)**
-* <a name="term-broker"></a>**[Broker](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-broker)**
+* <a name="term-passport"></a>**[Passport](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-passport)**
+* <a name="term-passport-scoped-access-token"></a>**[Passport-Scoped Access Token](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-passport-scoped-access-token)**
+* <a name="term-passport-clearinghouse"></a>**[Passport Clearinghouse](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-passport-clearinghouse)**
+* <a name="term-visa-assertion"></a>**[Visa Assertion](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-visa-assertion)**
+* <a name="term-visa-assertion-source"></a>**[Visa Assertion Source](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-visa-assertion-source)**
+* <a name="term-visa-issuer"></a>**[Visa Issuer](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-visa-issuer)**
+* <a name="term-visa"></a>**[Visa](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-visa)**
+* <a name="term-jwt"></a>**[JWT](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-jwt)**
+* <a name="term-ga4gh-claim"></a>**[GA4GH Claim](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-ga4gh-claim)**
+* <a name="term-broker"></a>**[Broker](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-broker)**
 
 ### Term Definitions
 
@@ -124,7 +124,7 @@ specification, namely these terms:
 
 ## Overview
 
-Please see the [Flow of Assertions](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#flow-of-assertions)
+Please see the [Flow of Assertions](https://ga4gh.github.io/data-security/aai-openid-connect-profile#flow-of-assertions)
 section in the GA4GH AAI OIDC Profile specification for an overview of interaction among the specified parties.
 
 
@@ -229,13 +229,13 @@ Claim](#example-passport-claim) section of the specification.
 ### Visa Requirements
 
 -   Visas MUST conform to one of the
-    [GA4GH AAI Specification Visa formats](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#visa-issued-by-visa-issuer)
+    [GA4GH AAI Specification Visa formats](https://ga4gh.github.io/data-security/aai-openid-connect-profile#visa-issued-by-visa-issuer)
     as JWS Compact Serialization strings as defined by [RFC7515 section
     7.1](https://tools.ietf.org/html/rfc7515#section-7.1).
 
 -   Visa Issuers, Brokers, and Passport Clearinghouses
     MUST conform to the
-    [GA4GH AAI Specification](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile)
+    [GA4GH AAI Specification](https://ga4gh.github.io/data-security/aai-openid-connect-profile)
     requirements for Visas in their use of Visas.
     
 -   Validation, as outlined elsewhere in this specification and the
@@ -274,7 +274,7 @@ When decoded, their structure is:
 The standard JWT payload claims `iss`, `sub`, `iat`, `exp` are all REQUIRED.
 
 One of `scope` or `jku` MUST be present as described in
-[Conformance for Visa Issuers](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#conformance-for-visa-issuers)
+[Conformance for Visa Issuers](https://ga4gh.github.io/data-security/aai-openid-connect-profile#conformance-for-visa-issuers)
 within the AAI specification.
 
 Claims within the `ga4gh_visa_v1` [Visa Object](#visa-object) are as described
@@ -283,9 +283,9 @@ in the [Visa Object Claims](#visa-object-claims) section of this specification.
 #### "**typ**"
 
 - OPTIONAL. The value of the `typ` header claim is RECOMMENDED to be `vnd.ga4gh.visa+jwt`
-  for [Visa Document Token Format](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#visa-document-token-format)
+  for [Visa Document Token Format](https://ga4gh.github.io/data-security/aai-openid-connect-profile#visa-document-token-format)
   visas. The value `JWT` marking  general JWTs MAY also be used.
-- For [Visa Access Token Format](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#visa-access-token-format)
+- For [Visa Access Token Format](https://ga4gh.github.io/data-security/aai-openid-connect-profile#visa-access-token-format)
   visas the value is unspecified, but it would likely be `at+jwt` as required by [section 2.1 of RFC 9068](https://datatracker.ietf.org/doc/html/rfc9068#section-2.1)
   for JWT access tokens.
 - The `typ` header claim is specified by [section 5.1 of JWT RFC](https://datatracker.ietf.org/doc/html/rfc7519#section-5.1)
@@ -299,7 +299,7 @@ in the [Visa Object Claims](#visa-object-claims) section of this specification.
 
 #### "**alg**"
 
-- REQUIRED.The section [Signing Algorithms](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#signing-algorithms)
+- REQUIRED.The section [Signing Algorithms](https://ga4gh.github.io/data-security/aai-openid-connect-profile#signing-algorithms)
 in the AAI specification lists possible algorithms used in the `alg` header claim.
 
 
@@ -1030,7 +1030,7 @@ Where:
 
 -   `accessTokenTTL` represents the duration for which an access token will be
     accepted and is bounded by the next refresh token cycle or [Access Token
-    Polling](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#at-polling)
+    Polling](https://ga4gh.github.io/data-security/aai-openid-connect-profile#at-polling)
     cycle or any larger propagation delay before access is revoked, which
     needs to be assessed based on the revocation model.
     
@@ -1047,7 +1047,7 @@ the access policy.
 ## Token Revocation
 
 As per the [GA4GH AAI Specification on Token
-Revocation](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#token-revocation),
+Revocation](https://ga4gh.github.io/data-security/aai-openid-connect-profile#token-revocation),
 the following mechanisms are available within Visa:
 
 1.  Visa Objects have an "[asserted](#asserted)" claim to allow
@@ -1066,8 +1066,8 @@ Systems employing Visas MUST provide mechanisms to
 limit the life of access, and specifically MUST conform to the GA4GH AAI
 Specification requirements in this regard. Systems utilizing Visas MAY also
 employ other mechanisms outlined in the GA4GH AAI Specification, such as [Access
-Token Polling](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#at-polling)
-if the Visa is encoded as a [Visa Access Token](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-visa-access-token-format). 
+Token Polling](https://ga4gh.github.io/data-security/aai-openid-connect-profile#at-polling)
+if the Visa is encoded as a [Visa Access Token](https://ga4gh.github.io/data-security/aai-openid-connect-profile#term-visa-access-token-format). 
 
 ## Example Passport Claim
 

--- a/researcher_ids/ga4gh_passport_v1.md
+++ b/researcher_ids/ga4gh_passport_v1.md
@@ -35,19 +35,19 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 This specification inherits terminology from the 
-[GA4GH AAI OIDC Profile](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#terminology)
+[GA4GH AAI OIDC Profile](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#terminology)
 specification, namely these terms:
 
-* <a name="term-passport"></a>**[Passport](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-passport)**
-* <a name="term-passport-scoped-access-token"></a>**[Passport-Scoped Access Token](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-passport-scoped-access-token)**
-* <a name="term-passport-clearinghouse"></a>**[Passport Clearinghouse](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-passport-clearinghouse)**
-* <a name="term-visa-assertion"></a>**[Visa Assertion](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-visa-assertion)**
-* <a name="term-visa-assertion-source"></a>**[Visa Assertion Source](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-visa-assertion-source)**
-* <a name="term-visa-issuer"></a>**[Visa Issuer](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-visa-issuer)**
-* <a name="term-visa"></a>**[Visa](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-visa)**
-* <a name="term-jwt"></a>**[JWT](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-jwt)**
-* <a name="term-ga4gh-claim"></a>**[GA4GH Claim](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-ga4gh-claim)**
-* <a name="term-broker"></a>**[Broker](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-broker)**
+* <a name="term-passport"></a>**[Passport](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-passport)**
+* <a name="term-passport-scoped-access-token"></a>**[Passport-Scoped Access Token](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-passport-scoped-access-token)**
+* <a name="term-passport-clearinghouse"></a>**[Passport Clearinghouse](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-passport-clearinghouse)**
+* <a name="term-visa-assertion"></a>**[Visa Assertion](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-visa-assertion)**
+* <a name="term-visa-assertion-source"></a>**[Visa Assertion Source](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-visa-assertion-source)**
+* <a name="term-visa-issuer"></a>**[Visa Issuer](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-visa-issuer)**
+* <a name="term-visa"></a>**[Visa](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-visa)**
+* <a name="term-jwt"></a>**[JWT](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-jwt)**
+* <a name="term-ga4gh-claim"></a>**[GA4GH Claim](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-ga4gh-claim)**
+* <a name="term-broker"></a>**[Broker](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-broker)**
 
 ### Term Definitions
 
@@ -124,7 +124,7 @@ specification, namely these terms:
 
 ## Overview
 
-Please see the [Flow of Assertions](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#flow-of-assertions)
+Please see the [Flow of Assertions](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#flow-of-assertions)
 section in the GA4GH AAI OIDC Profile specification for an overview of interaction among the specified parties.
 
 
@@ -229,13 +229,13 @@ Claim](#example-passport-claim) section of the specification.
 ### Visa Requirements
 
 -   Visas MUST conform to one of the
-    [GA4GH AAI Specification Visa formats](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#visa-issued-by-visa-issuer)
+    [GA4GH AAI Specification Visa formats](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#visa-issued-by-visa-issuer)
     as JWS Compact Serialization strings as defined by [RFC7515 section
     7.1](https://tools.ietf.org/html/rfc7515#section-7.1).
 
 -   Visa Issuers, Brokers, and Passport Clearinghouses
     MUST conform to the
-    [GA4GH AAI Specification](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md)
+    [GA4GH AAI Specification](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile)
     requirements for Visas in their use of Visas.
     
 -   Validation, as outlined elsewhere in this specification and the
@@ -274,7 +274,7 @@ When decoded, their structure is:
 The standard JWT payload claims `iss`, `sub`, `iat`, `exp` are all REQUIRED.
 
 One of `scope` or `jku` MUST be present as described in
-[Conformance for Visa Issuers](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#conformance-for-visa-issuers)
+[Conformance for Visa Issuers](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#conformance-for-visa-issuers)
 within the AAI specification.
 
 Claims within the `ga4gh_visa_v1` [Visa Object](#visa-object) are as described
@@ -283,9 +283,9 @@ in the [Visa Object Claims](#visa-object-claims) section of this specification.
 #### "**typ**"
 
 - OPTIONAL. The value of the `typ` header claim is RECOMMENDED to be `vnd.ga4gh.visa+jwt`
-  for [Visa Document Token Format](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#visa-document-token-format)
+  for [Visa Document Token Format](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#visa-document-token-format)
   visas. The value `JWT` marking  general JWTs MAY also be used.
-- For [Visa Access Token Format](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#visa-access-token-format)
+- For [Visa Access Token Format](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#visa-access-token-format)
   visas the value is unspecified, but it would likely be `at+jwt` as required by [section 2.1 of RFC 9068](https://datatracker.ietf.org/doc/html/rfc9068#section-2.1)
   for JWT access tokens.
 - The `typ` header claim is specified by [section 5.1 of JWT RFC](https://datatracker.ietf.org/doc/html/rfc7519#section-5.1)
@@ -299,7 +299,7 @@ in the [Visa Object Claims](#visa-object-claims) section of this specification.
 
 #### "**alg**"
 
-- REQUIRED.The section [Signing Algorithms](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#signing-algorithms)
+- REQUIRED.The section [Signing Algorithms](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#signing-algorithms)
 in the AAI specification lists possible algorithms used in the `alg` header claim.
 
 
@@ -1030,7 +1030,7 @@ Where:
 
 -   `accessTokenTTL` represents the duration for which an access token will be
     accepted and is bounded by the next refresh token cycle or [Access Token
-    Polling](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#at-polling)
+    Polling](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#at-polling)
     cycle or any larger propagation delay before access is revoked, which
     needs to be assessed based on the revocation model.
     
@@ -1047,7 +1047,7 @@ the access policy.
 ## Token Revocation
 
 As per the [GA4GH AAI Specification on Token
-Revocation](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#token-revocation),
+Revocation](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#token-revocation),
 the following mechanisms are available within Visa:
 
 1.  Visa Objects have an "[asserted](#asserted)" claim to allow
@@ -1066,8 +1066,8 @@ Systems employing Visas MUST provide mechanisms to
 limit the life of access, and specifically MUST conform to the GA4GH AAI
 Specification requirements in this regard. Systems utilizing Visas MAY also
 employ other mechanisms outlined in the GA4GH AAI Specification, such as [Access
-Token Polling](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#at-polling)
-if the Visa is encoded as a [Visa Access Token](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#term-visa-access-token-format). 
+Token Polling](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#at-polling)
+if the Visa is encoded as a [Visa Access Token](https://ga4gh.github.io/data-security/1.2-draft-main/aai-openid-connect-profile#term-visa-access-token-format). 
 
 ## Example Passport Claim
 


### PR DESCRIPTION
Change AAI spec links to published site https://ga4gh.github.io/data-security/aai-openid-connect-profile rather than markdown source file https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md.

The test commit https://github.com/ga4gh-duri/ga4gh-duri.github.io/pull/58/commits/d5003c7a0f2c9bd8d4c975f8dd48f8b4d1d4b76e links to the  AAI spec `1.2-draft-main` branch. 

This PR will be merged after the AAI 1.2 draft is merged to main and the final links are live.