### PR TITLE
Mark "typ" as optional in Visa

### DIFF
--- a/researcher_ids/ga4gh_passport_v1.md
+++ b/researcher_ids/ga4gh_passport_v1.md
@@ -249,7 +249,7 @@ When decoded, their structure is:
 
 ```
 {
-  "typ": "vnd.ga4gh.visa+jwt | at+jwt | JWT",
+  ["typ": "vnd.ga4gh.visa+jwt | at+jwt | JWT",]
   "alg": "<signing-algorithm>",
   ["jku": "<json-web-keys-set-URL>",]
   "kid": "<signing-key-identifier>"


### PR DESCRIPTION
Current schema is in conflict with the description below, where "typ" field of the JWT header is marked OPTIONAL.